### PR TITLE
The SVG and DOM property configs have moved to react-dom

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,9 +28,11 @@
     "babel-preset-es2015": "^6.9.0",
     "babel-preset-stage-1": "^6.5.0",
     "in-publish": "^2.0.0",
-    "react": "^15.4.0"
+    "react": "^15.4.0",
+    "react-dom": "^15.4.0"
   },
   "peerDependencies": {
-    "react": "^15.4.0"
+    "react": "^15.4.0",
+    "react-dom": "^15.4.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -28,9 +28,9 @@
     "babel-preset-es2015": "^6.9.0",
     "babel-preset-stage-1": "^6.5.0",
     "in-publish": "^2.0.0",
-    "react": "^15.1.0"
+    "react": "^15.4.0"
   },
   "peerDependencies": {
-    "react": "^0.14 || ^15.0"
+    "react": "^15.4.0"
   }
 }

--- a/src/react-properties-map.js
+++ b/src/react-properties-map.js
@@ -1,5 +1,5 @@
-import ReactHTMLDOMPropertyConfig from 'react/lib/HTMLDOMPropertyConfig'
-import ReactSVGDOMPropertyConfig from 'react/lib/SVGDOMPropertyConfig'
+import ReactHTMLDOMPropertyConfig from 'react-dom/lib/HTMLDOMPropertyConfig'
+import ReactSVGDOMPropertyConfig from 'react-dom/lib/SVGDOMPropertyConfig'
 
 /**
  * Object with HTML attributes mapped to React properties (IDL attributes)


### PR DESCRIPTION
This will add support for react ^15.4.0, where the `HTMLDOMPropertyConfig` and `SVGDOMPropertyConfig` have been moved to `react-dom`.

You could probably bump a major version if you merge this, since it's a breaking change.