### PR TITLE
don't trim whitespaces in text nodes

### DIFF
--- a/src/is-node-supported.js
+++ b/src/is-node-supported.js
@@ -42,5 +42,5 @@ const isNodeTypeIgnored = (nodeType) => (
  * @return {Boolean}
  */
 const isNodeValueIgnored = (nodeValue) => (
-  nodeValue !== null && nodeValue.trim() === ''
+  nodeValue !== null && nodeValue === ''
 )

--- a/test/html2react.test.jsx
+++ b/test/html2react.test.jsx
@@ -22,6 +22,10 @@ const dataset = [
   &quot;foo&quot; : &quot;bar&quot;
 }</pre>`
   },
+  {
+    input: "<pre><span>foo</span>\n<span>bar</span>\n</pre>",
+    output: "<pre><span>foo</span>\n<span>bar</span>\n</pre>",
+  },
 
   {
     input: `<textarea>{


### PR DESCRIPTION
Whitespaces are important for elements with style `white-space: nowrap`, or elements in `<pre>`, as the test case shows.