### PR TITLE
propValue.trim() sometimes causes TypeError

### DIFF
--- a/src/get-props-from-attributes.js
+++ b/src/get-props-from-attributes.js
@@ -30,12 +30,11 @@ function getStylePropValue (attrValue) {
   })
 
   return props.reduce((props, prop) => {
-    let [propName, propValue] = prop.split(/:(.+)?/)
+    let [propName, propValue] = prop.split(/:/)
     propName = formatStylePropName(propName)
-    propValue = propValue.trim()
     return {
       ...props,
-      [propName]: propValue
+      [propName]: propValue && propValue.trim(),
     }
   }, {})
 }

--- a/src/get-props-from-attributes.js
+++ b/src/get-props-from-attributes.js
@@ -30,7 +30,7 @@ function getStylePropValue (attrValue) {
   })
 
   return props.reduce((props, prop) => {
-    let [propName, propValue] = prop.split(/:/)
+    let [propName, propValue] = prop.split(/:(.*)/)
     propName = formatStylePropName(propName)
     return {
       ...props,

--- a/test/get-props-from-attributes.test.js
+++ b/test/get-props-from-attributes.test.js
@@ -44,7 +44,19 @@ it("gets props from <span style='...'/> element", () => {
         .toEqual({
             style: {
                 color: 'red',
-                fontWeight: 'bold'
+                fontWeight: 'bold',
+            },
+        });
+});
+
+it("works with invalid styles", () => {
+    const element = toElement('<span style="color:;font-size">foo</span>');
+
+    expect(getPropsFromAttributes(element))
+        .toEqual({
+            style: {
+                color: '',
+                fontSize: undefined,
             },
         });
 });

--- a/test/get-props-from-attributes.test.js
+++ b/test/get-props-from-attributes.test.js
@@ -49,6 +49,18 @@ it("gets props from <span style='...'/> element", () => {
         });
 });
 
+it("gets props from <span style='...'/> element, where style values includes :", () => {
+    const element = toElement('<span style="background-image: url(http://example.com/foo.png)">foo</span>');
+
+    expect(getPropsFromAttributes(element))
+        .toEqual({
+            style: {
+                backgroundImage: 'url(http://example.com/foo.png)',
+            },
+        });
+});
+
+
 it("works with invalid styles", () => {
     const element = toElement('<span style="color:;font-size">foo</span>');
 


### PR DESCRIPTION
I have errors from HTML2React when it processes user-generated contents.

I guess that's because it can't handle broken styles, and this PR fixes it.