### PR TITLE
makes <script/> overridable

### DIFF
--- a/src/is-node-supported.js
+++ b/src/is-node-supported.js
@@ -2,25 +2,10 @@ import NodeType from './node-type'
 
 export default function isNodeSupported (node = {}) {
   return !(
-    isTagNameIgnored(node.tagName) ||
     isNodeTypeIgnored(node.nodeType) ||
     isNodeValueIgnored(node.nodeValue)
   )
 }
-
-/**
- * Tag names that are not supported.
- * @type {Array}
- */
-const IGNORED_TAG_NAMES = ['script']
-/**
- * Checks if provided tag name is ignored (not supported).
- * @param {String} tagName
- * @return {Boolean}
- */
-const isTagNameIgnored = (tagName = '') => (
-  IGNORED_TAG_NAMES.indexOf(tagName.toLowerCase()) > -1
-)
 
 /**
  * Node types that are not supported.

--- a/src/parse-nodes.js
+++ b/src/parse-nodes.js
@@ -6,9 +6,14 @@ import isNodeSupported from './is-node-supported'
 import NodeType from './node-type'
 
 export default function parseNodes (nodes = [], elementOverrides = {}) {
+  const overrides = {
+    script: (props) => null,
+    ...elementOverrides,
+  };
+
   return Array.from(nodes).filter(isNodeSupported).map((node, index) => {
     if (node.nodeType === NodeType.ELEMENT) {
-      return parseElementNode(node, index, elementOverrides)
+      return parseElementNode(node, index, overrides)
     }
     return node.nodeValue
   })

--- a/test/script.test.jsx
+++ b/test/script.test.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+import renderer from 'react-test-renderer';
+
+import HTML2React from '../src';
+
+jest.autoMockOff();
+
+it("removes <script> by default", () => {
+  const h2r = HTML2React({})
+  expect(renderToStaticMarkup(<div>{h2r(`<script>document.write("Hello!")</script>`)}</div>).replace(/(?:^<div[^>]*>)|(?:<\/div>$)/g, ''))
+    .toBe("")
+})
+
+it("overrides <script> explicitly", () => {
+  const h2r = HTML2React({
+    script: (props) => {
+      return <code>{props.children}</code>;
+    },
+  })
+  expect(renderToStaticMarkup(<div>{h2r(`<script>document.write("Hello!")</script>`)}</div>).replace(/(?:^<div[^>]*>)|(?:<\/div>$)/g, ''))
+    .toBe(`<code>document.write(&quot;Hello!&quot;)</code>`)
+})


### PR DESCRIPTION
Ignoring `<script/>` by default is natural to me but I'd like to override it in some cases.

This PR makes `<script/>` overridable if users explicitly configure so.