### PR TITLE
performance improvement

### DIFF
--- a/src/get-element-override.js
+++ b/src/get-element-override.js
@@ -4,7 +4,7 @@ export default function getElementOverride (element, overrides) {
   for (const override in overrides) {
     if (overrides.hasOwnProperty(override)) {
       try {
-        const matches = parentNode.getElementsByTagName(override)
+        const matches = parentNode.querySelectorAll(override)
         if (Array.prototype.indexOf.call(matches, element) > -1) {
           return overrides[override]
         }

--- a/src/get-element-override.js
+++ b/src/get-element-override.js
@@ -1,11 +1,11 @@
 export default function getElementOverride (element, overrides) {
   const parentNode = getTopMostElementParent(element)
 
-  for (let override in overrides) {
+  for (const override in overrides) {
     if (overrides.hasOwnProperty(override)) {
       try {
-        const matches = parentNode.querySelectorAll(override)
-        if (Array.from(matches).indexOf(element) > -1) {
+        const matches = parentNode.getElementsByTagName(override)
+        if (Array.prototype.indexOf.call(matches, element) > -1) {
           return overrides[override]
         }
       } catch (e) {

--- a/test/html2react.test.jsx
+++ b/test/html2react.test.jsx
@@ -53,3 +53,15 @@ it("overrides elements", () => {
   expect(renderToStaticMarkup(<div>{HTML2React(input, elementOverrides)}</div>).replace(/(?:^<div[^>]*>)|(?:<\/div>$)/g, ''))
     .toBe(output)
 });
+
+it("overrides elements with CSS selectors", () => {
+  const input = `<a href="/">foo</a><a href="/" class="external">bar</a>`;
+  const output = `<a href="/">foo</a><a href="/" class="external" target="_blank">bar</a>`;
+  const elementOverrides = {
+    "a.external": (props) => {
+      return <a {...props} target="_blank"/>;
+    },
+  }
+  expect(renderToStaticMarkup(<div>{HTML2React(input, elementOverrides)}</div>).replace(/(?:^<div[^>]*>)|(?:<\/div>$)/g, ''))
+    .toBe(output)
+});

--- a/test/html2react.test.jsx
+++ b/test/html2react.test.jsx
@@ -41,3 +41,15 @@ dataset.forEach(({ input, output }) => {
       .toBe(output)
   })
 });
+
+it("overrides elements", () => {
+  const input = `<a href="/">link</a>`;
+  const output = `<a href="/" target="_blank">link</a>`;
+  const elementOverrides = {
+    a: (props) => {
+      return <a {...props} target="_blank"/>;
+    },
+  }
+  expect(renderToStaticMarkup(<div>{HTML2React(input, elementOverrides)}</div>).replace(/(?:^<div[^>]*>)|(?:<\/div>$)/g, ''))
+    .toBe(output)
+});


### PR DESCRIPTION
* <del>`getElementsByTagName` is about much faster than `querySelectorAll`</del>
  * https://jsperf.com/queryselectorall-vs-getelementsbytagname
* [x] `Array.prototype.indexOf.call` is about much faster than `Array.from(...).indexOf`
  * https://jsperf.com/array-from-x-indexof-vs-array-prototype-indexof