### PR TITLE
Whitlelist files included in package

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,11 @@
     "prepublish": "not-in-install && npm prune && npm test && npm run build || in-install",
     "test": "jest"
   },
+  "files": [
+    "lib/",
+    "README.md",
+    "LICENSE"
+  ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/Deschtex/html2react.git"

--- a/package.json
+++ b/package.json
@@ -9,9 +9,7 @@
     "test": "jest"
   },
   "files": [
-    "lib/",
-    "README.md",
-    "LICENSE"
+    "lib/"
   ],
   "repository": {
     "type": "git",


### PR DESCRIPTION
The artefacts of this library is already built and that means we can only include the built files to the client. What we need is the .babelrc to not be included because it interferes with the consumers buildsystems. 